### PR TITLE
Update Sharer.sol

### DIFF
--- a/contracts/Sharer.sol
+++ b/contracts/Sharer.sol
@@ -74,13 +74,12 @@ contract Sharer {
     }
 
     function distribute(address _rewards) public{
-        require(totalShare > 0);
         IERC20 reward = IERC20(_rewards);
 
         uint256 totalRewards = reward.balanceOf(address(this));
         uint256 remainingRewards = totalRewards;
 
-        if(totalRewards > totalShare){
+        if(totalRewards > 1000){
 
             for(uint256 i = 0; i < contributors.length; i++ ){
                 address cont = contributors[i];

--- a/contracts/Sharer.sol
+++ b/contracts/Sharer.sol
@@ -9,70 +9,86 @@ contract Sharer {
     using SafeERC20 for IERC20;
     using Address for address;
     using SafeMath for uint256;
-
-    mapping(address => uint256) public shares;
-    address private owner;
+    
+    
+    event contributorAdded(address _con, uint256 _shares, uint256 _total);
+    event contributorDeleted(address _con, uint256 _total);
+    struct Contributor {
+        uint256 numOfShares;
+        bool exists;
+    }
+    mapping(address => Contributor) public shares;
+    address public owner;
+    uint256 public totalShare;
     address[] public contributors;
 
 
     constructor() public {
         owner = msg.sender;
+        totalShare = 0;
+    }
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
     }
 
-    //share out of 1000
-    function addContributor(address con, uint256 share) public {
-        require(msg.sender == owner);
-        uint256 totalShare = share;
-
-        for(uint256 i = 0; i < contributors.length; i++ ){
-            totalShare += shares[contributors[i]];
+    //Change shares of a contributor or sets
+    function addContributor(address _con, uint256 _share) public onlyOwner {
+        uint256 oldShares = 0;
+        if (shares[_con].exists) {
+            oldShares  = shares[_con].numOfShares;
+            //set new number of shares for existing contributor
+            shares[_con].numOfShares = _share;
+        } else {
+        //add new contributor
+        shares[_con] = Contributor(_share, true);
+        contributors.push(_con);
         }
-
-        require(totalShare < 1000, "share total more than 100%");
-
-        contributors.push(con);
-        shares[con] = share;
-
+        //update totalShare
+        totalShare = totalShare - oldShares + _share;
+        //revert if we pushed the total over 1000...
+        require (totalShare < 1000, "share total more than 100%");
+        emit contributorAdded(_con, _share, totalShare);
     }
 
-    function removeContributor(address con) public {
-        require(msg.sender == owner);
-
-        for(uint256 i = 0; i < contributors.length; i++ ){
-
-            if(contributors[i] == con){
-                //put the last index here
-                //remove last index
-                if (i != contributors.length-1) {
-                    contributors[i] = contributors[contributors.length - 1];
+    function removeContributor(address _con) public onlyOwner {
+        uint256 oldShares = 0;
+        if (shares[_con].exists) {
+            oldShares  = shares[_con].numOfShares;
+            //Remove the address from the array
+            for(uint256 i = 0; i < contributors.length; i++ ){
+                if(contributors[i] == _con){
+                    //put the last index here
+                    //remove last index
+                    if (i != contributors.length-1) {
+                        contributors[i] = contributors[contributors.length - 1];
+                    }
+                    //pop shortens array by 1 thereby deleting the last index
+                    contributors.pop();
                 }
-
-                //pop shortens array by 1 thereby deleting the last index
-                contributors.pop();
             }
-           
+            totalShare = totalShare - oldShares;
+            delete shares[_con];
+            emit contributorDeleted(_con, totalShare);
         }
-        shares[con] = 0;
-
     }
 
-    function distribute(address rewards) public{
-
-        IERC20 reward = IERC20(rewards);
+    function distribute(address _rewards) public{
+        require(totalShare > 0);
+        IERC20 reward = IERC20(_rewards);
 
         uint256 totalRewards = reward.balanceOf(address(this));
         uint256 remainingRewards = totalRewards;
 
-        if(totalRewards > 1){
+        if(totalRewards > totalShare){
 
             for(uint256 i = 0; i < contributors.length; i++ ){
                 address cont = contributors[i];
-                uint256 share = totalRewards.mul(shares[cont]).div(1000);
+                uint256 share = totalRewards.mul(shares[cont].numOfShares).div(1000);
                 reward.safeTransfer(cont, share);
 
                 remainingRewards -= share;
             }
-
             reward.safeTransfer(owner, remainingRewards);
         }
     }

--- a/contracts/Sharer.sol
+++ b/contracts/Sharer.sol
@@ -78,14 +78,11 @@ contract Sharer {
 
         uint256 totalRewards = reward.balanceOf(address(this));
         uint256 remainingRewards = totalRewards;
-
         if(totalRewards > 1000){
-
             for(uint256 i = 0; i < contributors.length; i++ ){
                 address cont = contributors[i];
                 uint256 share = totalRewards.mul(shares[cont].numOfShares).div(1000);
                 reward.safeTransfer(cont, share);
-
                 remainingRewards -= share;
             }
             reward.safeTransfer(owner, remainingRewards);


### PR DESCRIPTION
Tested here https://kovan.etherscan.io/address/0x6f01180dce6b2e53ec5a19f5afcc6cbfc25aacfa

The old version goes into an ugly state if you add the same address twice and try to remove it again. With this you can just adjust the share of an address by calling addContributor again.
Added some convenience functions and events (in the assumption, that the functions are not called by users and not called frequently).